### PR TITLE
feat(dynamodb)!: changed to dap registry get_pipelines to be by id and added get_pipelines_by_name

### DIFF
--- a/capepy/aws/dynamodb.py
+++ b/capepy/aws/dynamodb.py
@@ -1,5 +1,6 @@
 import os
 
+from boto3.dynamodb.conditions import ConditionExpressionBuilder, Key
 from botocore.exceptions import ClientError
 
 from capepy.aws.meta import Boto3Object
@@ -68,9 +69,54 @@ class Table(Boto3Object):
 
         return ret
 
+    def query_items(self, index_name, key_cond_exp):
+        """Retrieve items from the loaded table using a secondary index.
+
+        Args:
+            index_name: The name of the index to query.
+            key_cond_exp: The key condition expression to use in the query.
+
+        Returns:
+            The items value from the DyamoDB table. Any valid query results
+            will come back as a list (including an empty list for no match),
+            None is returned if there is an error.
+        """
+        ret = None
+
+        try:
+            response = self.table.query(
+                IndexName=index_name, KeyConditionExpression=key_cond_exp
+            )
+            ret = response.get("Items")
+
+        except ClientError as err:
+            code, message = decode_error(err)
+
+            # the key condition is not real easy to print in a good way, but we
+            # do our best.
+            ceb = ConditionExpressionBuilder()
+            kce = ceb.build_expression(key_cond_exp, is_key_condition=True)
+
+            kce_str = (
+                f"Expression: {kce.condition_expression} "
+                f"Expression Attr Names: {kce.attribute_name_placeholders} "
+                f"Expression Attr Values: {kce.attribute_value_placeholders} "
+            )
+
+            self.logger.error(
+                f"Couldn't get DynamoDB entries for in index '{index_name}' "
+                f"with key condition expression '{kce_str}' in table {self.name}. "
+                f"{code} {message}"
+            )
+
+        return ret
+
 
 class PipelineTable(Table):
     """A DynamoDB table with specific structure for organizing analysis pipelines."""
+
+    # name of the index that we query with name and version
+    NAME_VER_GSI = "PipelineNameVerIndex"
 
     def __init__(self, table_name=None):
         """Constructor to fetch and initialize a DynamoDB analysis pipeline table.
@@ -82,22 +128,25 @@ class PipelineTable(Table):
             table_name = os.getenv("DAP_REG_DDB_TABLE")
         super().__init__(table_name)
 
-    def get_pipeline(self, pipeline_name, pipeline_version):
-        """Retrieve a specific pipeline from the table.
+    def get_pipelines_by_name(self, pipeline_name, pipeline_version=None):
+        """Retrieve pipelines from the table matching name and optional version.
 
         Args:
             pipeline_name: The name of the pipeline.
-            pipeline_version: The version of the pipeline.
+            pipeline_version: The optional version of the pipeline.
 
         Returns:
-            The retrieved pipeline item.
+            The retrieved pipeline item(s) in a list (which will be empty in the
+            case of no match) or None on error.
         """
-        key = {"pipeline_name": pipeline_name}
-        if pipeline_version is not None:
-            key["version"] = pipeline_version
-        return self.get_item(key)
+        kce = Key("pipeline_name").eq(pipeline_name)
 
-    def get_pipeline_by_id(self, pipeline_id):
+        if pipeline_version is not None:
+            kce = kce & Key("version").eq(pipeline_version)
+
+        return self.query_items(self.NAME_VER_GSI, kce)
+
+    def get_pipeline(self, pipeline_id):
         """Retrieve a specific pipeline from the table.
 
         Args:


### PR DESCRIPTION
# TO TEST

Ran this locally. Feel free to recreate:

```
>>> from capepy.aws.dynamodb import PipelineTable
>>> pt=PipelineTable(table_name="cape-dap-registry-DataAnalysisPipelineRegistry")
>>> import pprint
>>> from capepy.aws.dynamodb import PipelineTable
>>> 
>>> 
>>> pt.get_pipeline("bactopia-ont-v3.2.0")
{'version': 'v3.2.0', 'pipeline_type': 'nextflow', 'pipeline_name': 'Bactopia ONT Sample', 'pipeline_runnable': True, 'pipeline_id': 'bactopia-ont-v3.2.0', 'profile': {'pipelineName': 'Bactopia ONT Sample', 'parametersSchema': {'allOf': [{'$ref': '#/$defs/bactopia-base-3.2.0'}], '$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'bactopia-base-3.2.0': {'$defs': {}, '$schema': 'https://json-schema.org/draft/2020-12/schema', 'type': 'object', 'properties': {'--aws_volumes': {'const': '/opt/conda:/mnt/conda,/mnt/nextflow_shared_data:/mnt/nextflow_shared_data:ro', 'default': '/opt/conda:/mnt/conda,/mnt/nextflow_shared_data:/mnt/nextflow_shared_data:ro'}, '-profile': {'const': 'aws', 'default': 'aws'}}}}, 'type': 'object', 'properties': {'--outdir': {'type': 'string', 'title': 'S3 Location of the output directory'}, '--max_memory': {'type': 'string', 'title': 'Max Memory', 'default': '24.GB'}, '--ont': {'type': 'string', 'title': 'ONT'}, '--max_cpus': {'default': Decimal('8'), 'type': 'integer', 'title': 'Max CPUs', 'minimum': Decimal('1')}, '--sample': {'type': 'string', 'title': 'Sample Name'}}, 'unevaluatedProperties': False, 'required': ['--sample', '--ont', '--outdir']}, 'pipelineDescription': "Execute Bactopia's ONT sample sequencing workflow with v3.2.0", 'uiSchema': {'type': 'VerticalLayout', 'elements': [{'type': 'Control', 'scope': '#/properties/--max_cpus'}, {'type': 'Control', 'scope': '#/properties/--max_memory'}, {'type': 'Control', 'scope': '#/properties/--ont'}, {'type': 'Control', 'scope': '#/properties/--sample'}]}, 'project': 'bactopia/bactopia', 'submission': {'encoding': 'cli-string', 'optionsFieldName': 'nextflowOptions'}, 'pipelineType': 'nextflow', 'version': 'v3.2.0', 'inherits': ['bactopia-base-3.2.0'], 'pipelineRunnable': True, 'pipelineId': 'bactopia-ont-v3.2.0'}, 'nextflow_config': {'aws': {'batch': {'cliPath': '/usr/bin/aws', 'delayBetweenAttempts': '5 sec', 'maxTransferAttempts': Decimal('3')}, 'client': {'uploadStorageClass': 'INTELLIGENT_TIERING', 'connectionTimeout': Decimal('10000'), 'storageEncryption': 'AES256', 'maxConnections': Decimal('20')}, 'secretKey': '<YOUR S3 SECRET KEY>', 'region': 'us-east-2', 'accessKey': '<YOUR S3 ACCESS KEY>'}}, 'project': 'bactopia/bactopia'}
>>> 
>>> 
>>> 
>>> items = pt.get_pipelines_by_name("Bactopia ONT Sample")
>>> len(items)
2
>>> items
[{'profile': {'parametersSchema': {'allOf': [{'$ref': '#/$defs/bactopia-base-dev'}], '$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'bactopia-base-dev': {'$defs': {}, '$schema': 'https://json-schema.org/draft/2020-12/schema', 'type': 'object', 'properties': {'--aws_volumes': {'const': '/opt/conda:/mnt/conda,/mnt/nextflow_shared_data:/mnt/nextflow_shared_data:ro', 'default': '/opt/conda:/mnt/conda,/mnt/nextflow_shared_data:/mnt/nextflow_shared_data:ro'}, '-profile': {'const': 'aws', 'default': 'aws'}}}}, 'type': 'object', 'required': ['--sample', '--ont', '--outdir'], 'properties': {'--outdir': {'title': 'S3 Location of the output directory', 'type': 'string'}, '--max_memory': {'title': 'Max Memory', 'type': 'string', 'default': '24.GB'}, '--max_cpus': {'default': Decimal('8'), 'type': 'integer', 'title': 'Max CPUs', 'minimum': Decimal('1')}, '--ont': {'type': 'string', 'title': 'ONT'}, '--sample': {'type': 'string', 'title': 'Sample Name'}}, 'unevaluatedProperties': False}, 'pipelineName': 'Bactopia ONT Sample', 'pipelineDescription': "Execute Bactopia's ONT sample sequencing workflow with the development release", 'uiSchema': {'type': 'VerticalLayout', 'elements': [{'type': 'Control', 'scope': '#/properties/--max_cpus'}, {'type': 'Control', 'scope': '#/properties/--max_memory'}, {'type': 'Control', 'scope': '#/properties/--ont'}, {'type': 'Control', 'scope': '#/properties/--sample'}]}, 'project': 'bactopia/bactopia', 'submission': {'encoding': 'cli-string', 'optionsFieldName': 'nextflowOptions'}, 'pipelineType': 'nextflow', 'version': 'dev', 'inherits': ['bactopia-base-dev'], 'pipelineRunnable': True, 'pipelineId': 'bactopia-ont-dev'}, 'project': 'bactopia/bactopia', 'pipeline_name': 'Bactopia ONT Sample', 'pipeline_runnable': True, 'version': 'dev', 'pipeline_id': 'bactopia-ont-dev', 'pipeline_type': 'nextflow', 'nextflow_config': {'aws': {'batch': {'cliPath': '/usr/bin/aws', 'delayBetweenAttempts': '5 sec', 'maxTransferAttempts': Decimal('3')}, 'client': {'uploadStorageClass': 'INTELLIGENT_TIERING', 'connectionTimeout': Decimal('10000'), 'storageEncryption': 'AES256', 'maxConnections': Decimal('20')}, 'secretKey': '<YOUR S3 SECRET KEY>', 'region': 'us-east-2', 'accessKey': '<YOUR S3 ACCESS KEY>'}}}, {'profile': {'pipelineName': 'Bactopia ONT Sample', 'parametersSchema': {'allOf': [{'$ref': '#/$defs/bactopia-base-3.2.0'}], '$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'bactopia-base-3.2.0': {'$defs': {}, '$schema': 'https://json-schema.org/draft/2020-12/schema', 'type': 'object', 'properties': {'--aws_volumes': {'const': '/opt/conda:/mnt/conda,/mnt/nextflow_shared_data:/mnt/nextflow_shared_data:ro', 'default': '/opt/conda:/mnt/conda,/mnt/nextflow_shared_data:/mnt/nextflow_shared_data:ro'}, '-profile': {'const': 'aws', 'default': 'aws'}}}}, 'type': 'object', 'properties': {'--outdir': {'type': 'string', 'title': 'S3 Location of the output directory'}, '--max_memory': {'type': 'string', 'title': 'Max Memory', 'default': '24.GB'}, '--ont': {'type': 'string', 'title': 'ONT'}, '--max_cpus': {'default': Decimal('8'), 'type': 'integer', 'title': 'Max CPUs', 'minimum': Decimal('1')}, '--sample': {'type': 'string', 'title': 'Sample Name'}}, 'unevaluatedProperties': False, 'required': ['--sample', '--ont', '--outdir']}, 'pipelineDescription': "Execute Bactopia's ONT sample sequencing workflow with v3.2.0", 'uiSchema': {'type': 'VerticalLayout', 'elements': [{'type': 'Control', 'scope': '#/properties/--max_cpus'}, {'type': 'Control', 'scope': '#/properties/--max_memory'}, {'type': 'Control', 'scope': '#/properties/--ont'}, {'type': 'Control', 'scope': '#/properties/--sample'}]}, 'project': 'bactopia/bactopia', 'submission': {'encoding': 'cli-string', 'optionsFieldName': 'nextflowOptions'}, 'pipelineType': 'nextflow', 'version': 'v3.2.0', 'inherits': ['bactopia-base-3.2.0'], 'pipelineRunnable': True, 'pipelineId': 'bactopia-ont-v3.2.0'}, 'pipeline_id': 'bactopia-ont-v3.2.0', 'project': 'bactopia/bactopia', 'pipeline_name': 'Bactopia ONT Sample', 'pipeline_runnable': True, 'pipeline_type': 'nextflow', 'version': 'v3.2.0', 'nextflow_config': {'aws': {'batch': {'cliPath': '/usr/bin/aws', 'delayBetweenAttempts': '5 sec', 'maxTransferAttempts': Decimal('3')}, 'client': {'uploadStorageClass': 'INTELLIGENT_TIERING', 'connectionTimeout': Decimal('10000'), 'storageEncryption': 'AES256', 'maxConnections': Decimal('20')}, 'secretKey': '<YOUR S3 SECRET KEY>', 'region': 'us-east-2', 'accessKey': '<YOUR S3 ACCESS KEY>'}}}]
>>> 
>>> 
>>> 
>>> item = pt.get_pipeline_by_name_ver("Bactopia ONT Sample", "v3.2.0")
>>> len(item)
1
>>> item
[{'pipeline_runnable': True, 'version': 'v3.2.0', 'nextflow_config': {'aws': {'batch': {'cliPath': '/usr/bin/aws', 'delayBetweenAttempts': '5 sec', 'maxTransferAttempts': Decimal('3')}, 'client': {'uploadStorageClass': 'INTELLIGENT_TIERING', 'connectionTimeout': Decimal('10000'), 'storageEncryption': 'AES256', 'maxConnections': Decimal('20')}, 'secretKey': '<YOUR S3 SECRET KEY>', 'region': 'us-east-2', 'accessKey': '<YOUR S3 ACCESS KEY>'}}, 'pipeline_name': 'Bactopia ONT Sample', 'project': 'bactopia/bactopia', 'pipeline_type': 'nextflow', 'pipeline_id': 'bactopia-ont-v3.2.0', 'profile': {'pipelineName': 'Bactopia ONT Sample', 'parametersSchema': {'allOf': [{'$ref': '#/$defs/bactopia-base-3.2.0'}], '$schema': 'https://json-schema.org/draft/2020-12/schema', '$defs': {'bactopia-base-3.2.0': {'$defs': {}, '$schema': 'https://json-schema.org/draft/2020-12/schema', 'type': 'object', 'properties': {'--aws_volumes': {'const': '/opt/conda:/mnt/conda,/mnt/nextflow_shared_data:/mnt/nextflow_shared_data:ro', 'default': '/opt/conda:/mnt/conda,/mnt/nextflow_shared_data:/mnt/nextflow_shared_data:ro'}, '-profile': {'const': 'aws', 'default': 'aws'}}}}, 'type': 'object', 'properties': {'--outdir': {'type': 'string', 'title': 'S3 Location of the output directory'}, '--max_memory': {'type': 'string', 'title': 'Max Memory', 'default': '24.GB'}, '--ont': {'type': 'string', 'title': 'ONT'}, '--max_cpus': {'default': Decimal('8'), 'type': 'integer', 'title': 'Max CPUs', 'minimum': Decimal('1')}, '--sample': {'type': 'string', 'title': 'Sample Name'}}, 'unevaluatedProperties': False, 'required': ['--sample', '--ont', '--outdir']}, 'pipelineDescription': "Execute Bactopia's ONT sample sequencing workflow with v3.2.0", 'uiSchema': {'type': 'VerticalLayout', 'elements': [{'type': 'Control', 'scope': '#/properties/--max_cpus'}, {'type': 'Control', 'scope': '#/properties/--max_memory'}, {'type': 'Control', 'scope': '#/properties/--ont'}, {'type': 'Control', 'scope': '#/properties/--sample'}]}, 'project': 'bactopia/bactopia', 'submission': {'encoding': 'cli-string', 'optionsFieldName': 'nextflowOptions'}, 'pipelineType': 'nextflow', 'version': 'v3.2.0', 'inherits': ['bactopia-base-3.2.0'], 'pipelineRunnable': True, 'pipelineId': 'bactopia-ont-v3.2.0'}}]
>>> 
>>> 
>>> 
>>> bad_vals = pt.get_pipeline("awsad")
>>> bad_vals
>>> bad_vals == None
True
>>> 
>>> 
>>> 
>>> bad_vals = pt.get_pipeline_by_name("awsad")
>>> bad_vals
[]
>>> bad_vals = pt.get_pipeline_by_name_ver("Bactopia ONT Sample", "awsad")
>>> bad_vals
[]


```
